### PR TITLE
Removing RANDFILE from openssl cnf

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,9 @@ jobs:
       - run:
           name: "Test: docker run --rm ${DOCKER_IMAGE} /usr/share/easy-rsa2/pkitool --version"
           command: docker run --rm ${DOCKER_IMAGE} /usr/share/easy-rsa2/pkitool --version
-
+      - run:
+          name: "Test: docker run --rm ${DOCKER_IMAGE} pip freeze | grep openvpn-cert-generator"
+          command: docker run --rm ${DOCKER_IMAGE} pip freeze | grep openvpn-cert-generator | awk -F '==' '{print $1 " module v"$2}'
       # Deploy steps:
       - run:
           name: "Deploy: Tag and push only on master branch"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.0.3
 - Updated to python 3
+- Removed RANDFILE from openssl.cnf to avoid errors [see commit](https://github.com/openssl/openssl/commit/0f58220973a02248ca5c69db59e615378467b9c8#diff-8ce6aaad88b10ed2b3b4592fd5c8e03aL13)
 
 ## 0.0.2
 - Changes to make docker image more focused specifically on generating certificates, and working with S3.

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,9 @@ RUN set -ex && \
     mv /tmp/EasyRSA-${EASY_RSA_2_VERSION}/* ${EASY_RSA_2_DIR} && \
     # Get easy-rsa2 to source in a CRL expire time period instead of using the default 30 days
     sed -i 's/default_crl_days=\ 30/default_crl_days=\ \$ENV::EASYRSA_CRL_DAYS/g' /usr/share/easy-rsa2/openssl-1.0.0.cnf && \
+    # Remove deprecated RANDFILE to avoid error
+    # https://github.com/openssl/openssl/commit/0f58220973a02248ca5c69db59e615378467b9c8#diff-8ce6aaad88b10ed2b3b4592fd5c8e03aL13
+    sed -i 's/^\(RANDFILE.*\)$/#\1/g' /usr/share/easy-rsa2/openssl-1.0.0.cnf && \
     # bad defaults in the openvpn-cert-generator pip package
     ln -s /usr/bin/aws /usr/local/bin/aws && \
     # cleanup

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Environment variables that one can use to override the built in defaults.
 - `ACTIVE_CLIENTS` (client) - is a comma-delimited list of active, valid client certs for the script to generate. The values here will generate client certs matching the comma-delimited name values.
   * The order of the client will affect the order the certs are generated, and correspond with their respective values in the `index.txt` and `serial` files. It's best not to change the order of existing certs once they are set.
   * `dummy` is the built in value that should cannot be used.
-- `REVOKED_CERTS` ('') - is a comma-delimited list of certs to revoke. Typically, this should be a subset of the values from the `ACTIVE_CLIENTS` list.
+- `REVOKED_CLIENTS` ('') - is a comma-delimited list of certs to revoke. Typically, this should be a subset of the values from the `ACTIVE_CLIENTS` list.
   * A revoked client should stay in the `ACTIVE_CLIENTS` list, to avoid the confusion in accidentally generating another certificate with the same name.
 - `OPENVPN_DEV` (tun) - controls the value generated in the client *.ovpn files for `dev`. For more information, see the documentation for openvpn regarding the `--dev` option`. This value needs to match the value used in the server configuration (which is not generate as part of these scripts).
 - `OPENVPN_PROTO` (tcp) - controls the value generated in the client *.ovpn files for `dev`. For more information, see the documentation for openvpn regarding the `--proto` option`. This value needs to match the value used in the server configuration (which is not generate as part of these scripts).


### PR DESCRIPTION
* Removed the RANDFILE directive from the openssl.cnf to avoid errors during cert generation.